### PR TITLE
Always resolve dora.dir

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -14,6 +14,13 @@ jobs:
       with:
         python-version: 3.7
 
+    - uses: actions/cache@v2
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,6 +14,13 @@ jobs:
       with:
         python-version: 3.7
 
+    - uses: actions/cache@v2
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+## [Unreleased]
+
+
+
+## [0.1.5] - 2017-06-20
+
+Added possiblity to log always the time per iteration rathen than iterations per seconds.
+[PR](https://github.com/facebookresearch/dora/pull/10).
+
+Fixed a bug with `DoraConf`, making sure that the `dir` attribute is always
+absolute, even when reset after creation, which could happen when using Hydra
+with a relative path for `dora.dir`.
+
+## [0.1.4] - 2021-09-15
+
+Initial release (first versions were private betas).

--- a/README.md
+++ b/README.md
@@ -39,11 +39,13 @@ pip install -U dora-search
 
 ## What's up?
 
-- 7 of September 2021: added support for a `git_save` option. This will ensure that the project git is clean
+See [the changelog](CHANGELOG.md) for details on releases.
+
+- 2021-09-29: version 0.1.5 released.
+- 2021-09-07: added support for a `git_save` option. This will ensure that the project git is clean
     and make a clone from which the experiment will run. This does not apply to `dora run` for easier
     debugging (but you can force it with `--git_save`).
-- 21 of June 2021: added support for Hydra 1.1. Be very careful if you update to Hydra 1.1, there are some non backward compatible changes in the way group config are parsed, see [the Hydra release notes](https://hydra.cc/docs/upgrades/1.0_to_1.1/default_composition_order) for more information.
-- 18 of June 2021: please upgrade Dora, there was a bug with the wrong number of gpus being scheduled 😇. 
+- 2021-06-21: added support for Hydra 1.1. Be very careful if you update to Hydra 1.1, there are some non backward compatible changes in the way group config are parsed, see [the Hydra release notes](https://hydra.cc/docs/upgrades/1.0_to_1.1/default_composition_order) for more information.
 
 (FB Only) If you are using Dora and want to receive updates on bug fixes and new versions, ping me (@defossez) on Workchat.
 

--- a/dora/__init__.py
+++ b/dora/__init__.py
@@ -60,6 +60,8 @@ width="400px"></p>
 __pdoc__ = {}
 __pdoc__['tests'] = False
 
+__version__ = "0.1.5"
+
 # flake8: noqa
 from .explore import Explorer, Launcher
 try:

--- a/dora/conf.py
+++ b/dora/conf.py
@@ -8,7 +8,7 @@
 Basic configuration for Dora is here.
 """
 from argparse import Namespace
-from dataclasses import dataclass, field, InitVar
+from dataclasses import dataclass, field
 from fnmatch import fnmatch
 from pathlib import Path
 import typing as tp

--- a/dora/conf.py
+++ b/dora/conf.py
@@ -133,7 +133,7 @@ class DoraConfig:
             A shallow clone of the repo will be made and execution will happen from there.
             This does not impact `dora run` unless you pass the `--git_save` flag.
     """
-    dir: tp.Union[str, Path] = Path("./outputs")  # where everything will be stored
+    dir: Path = Path("./outputs")  # where everything will be stored
     exclude: tp.List[str] = field(default_factory=list)
     git_save: bool = False
 

--- a/dora/tests/test_xp.py
+++ b/dora/tests/test_xp.py
@@ -21,6 +21,13 @@ def get_dora(tmpdir: Path):
     return DoraConfig(dir=Path(tmpdir), exclude=["a"])
 
 
+def test_dora_dir_abs():
+    dora = get_dora('outputs')
+    assert dora.dir.is_absolute()
+    dora.dir = 'plop'
+    assert dora.dir.is_absolute()
+
+
 def test_sig(tmpdir):
     tmpdir = Path(str(tmpdir))
     dora = get_dora(tmpdir)

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@
 # author: adefossez
 # Inspired from https://github.com/kennethreitz/setup.py
 
+from importlib.machinery import SourceFileLoader
 from pathlib import Path
 
 from setuptools import setup, find_packages
@@ -17,7 +18,11 @@ URL = 'https://github.com/facebookresearch/dora'
 EMAIL = 'defossez@fb.com'
 AUTHOR = 'Alexandre Défossez'
 REQUIRES_PYTHON = '>=3.7.0'
-VERSION = "0.1.4"
+
+# Trick taken from https://github.com/sigsep/sigsep-mus-db/blob/master/setup.py
+VERSION = SourceFileLoader(
+    'dora', 'dora/__init__.py'
+).load_module().__version__
 
 HERE = Path(__file__).parent
 

--- a/setup.py
+++ b/setup.py
@@ -19,10 +19,12 @@ EMAIL = 'defossez@fb.com'
 AUTHOR = 'Alexandre Défossez'
 REQUIRES_PYTHON = '>=3.7.0'
 
-# Trick taken from https://github.com/sigsep/sigsep-mus-db/blob/master/setup.py
-VERSION = SourceFileLoader(
-    'dora', 'dora/__init__.py'
-).load_module().__version__
+for line in open('dora/__init__.py'):
+    line = line.strip()
+    if '__version__' in line:
+        context = {}
+        exec(line, context)
+        VERSION = context['__version__']
 
 HERE = Path(__file__).parent
 


### PR DESCRIPTION
this remove a potential bug with hydra when using a relative `dora.dir` path. Also make things overall more reliable.