### PR TITLE
easier sharing of XPs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ Automatically simplfies argv list for Hydra experiments when same parameter is r
 Better error message when making a typo in the grid name. Always show the traceback when getting an
 import error.
 
+Added import/export command to easily share XP hyper-params in text form.
+
 ## [0.1.7] - 2021-11-08
 
 Adding support for type arrays.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@ import error.
 
 Added import/export command to easily share XP hyper-params in text form.
 
+Added shared repository option (`shared` option in Dora config). No metrics or
+checkpoints can be shared, this is still a bit dangerous, but this will act as a shared
+database for mappings from SIG -> hyper params, so that you can just pass a SIG
+to your teammate and launch the same XP.
+
 ## [0.1.7] - 2021-11-08
 
 Adding support for type arrays.

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ pip install -U dora-search
 
 See [the changelog](CHANGELOG.md) for details on releases.
 
+- 2021-12-10: version 0.1.8a: see changelog, many of small changes.
 - 2021-11-08: version 0.1.7: support for job arrays added.
 - 2021-10-20: version 0.1.6 released, bug fixes.
 - 2021-09-29: version 0.1.5 released.

--- a/dora/__init__.py
+++ b/dora/__init__.py
@@ -60,7 +60,7 @@ width="400px"></p>
 __pdoc__ = {}
 __pdoc__['tests'] = False
 
-__version__ = "0.1.8a5"
+__version__ = "0.1.8a6"
 
 # flake8: noqa
 from .explore import Explorer, Launcher

--- a/dora/__main__.py
+++ b/dora/__main__.py
@@ -20,6 +20,7 @@ from .info import info_action
 from .launch import launch_action
 from .log import fatal, setup_logging, simple_log
 from .run import run_action
+from .share import import_action, export_action
 from .utils import import_or_fatal
 
 
@@ -158,6 +159,13 @@ def get_parser():
     info.add_argument("-m", "--metrics", action="store_true", help="Show last metrics")
     info.add_argument("argv", nargs='*')
     info.set_defaults(action=info_action)
+
+    import_ = subparsers.add_parser("import")
+    import_.set_defaults(action=import_action)
+
+    export = subparsers.add_parser("export")
+    export.add_argument("sigs", nargs='*', help='All the XP sigs to export.')
+    export.set_defaults(action=export_action)
 
     return parser
 

--- a/dora/conf.py
+++ b/dora/conf.py
@@ -138,10 +138,14 @@ class DoraConfig:
         git_save (bool): when True, experiments can only be scheduled from a clean repo.
             A shallow clone of the repo will be made and execution will happen from there.
             This does not impact `dora run` unless you pass the `--git_save` flag.
+        shared (Path or None): if provided, the path to a central repository of XPs.
+            For the moment, this only supports sharing hyper-params, logs etc. will stay
+            in the per user folder.
     """
     dir: Path = Path("./outputs")  # where everything will be stored
     exclude: tp.List[str] = field(default_factory=list)
     git_save: bool = False
+    shared: tp.Optional[Path] = None  # Optional path for shared XPs.
 
     # Those are internal config values and are unlikely to be changed
     history: str = "history.json"  # where metrics will be stored
@@ -161,7 +165,8 @@ class DoraConfig:
         return False
 
     def __setattr__(self, name, value):
-        if name == 'dir':
+        if name in ['dir', 'shared']:
             from .git_save import to_absolute_path
-            value = Path(to_absolute_path(value))
+            if value is not None:
+                value = Path(to_absolute_path(value))
         super().__setattr__(name, value)

--- a/dora/main.py
+++ b/dora/main.py
@@ -91,10 +91,12 @@ class DecoratedMain(NamesMixin):
         can be easily shared using its signature.
         """
         xp.folder.mkdir(exist_ok=True, parents=True)
-        for path in [xp._argv_cache, xp._shared_argv_cache]:
-            if path is not None:
-                path.parent.mkdir(exist_ok=True, parents=True)
-                json.dump(xp.argv, open(path, 'w'))
+        json.dump(xp.argv, open(xp._argv_cache, 'w'))
+        if xp._shared_argv_cache is not None:
+            xp._shared_argv_cache.parent.mkdir(exist_ok=True, parents=True, mode=0o777)
+            xp._shared_argv_cache.parent.chmod(0o777)
+            json.dump(xp.argv, open(xp._shared_argv_cache, 'w'))
+            xp._shared_argv_cache.chmod(0o777)
         return xp
 
     def get_argv_from_sig(self, sig: str) -> tp.Sequence[str]:

--- a/dora/main.py
+++ b/dora/main.py
@@ -82,10 +82,19 @@ class DecoratedMain(NamesMixin):
         return sys.argv[1:]
 
     def init_xp(self, xp: XP):
-        # Initialize the XP just before the actual execution.
-        # This will create the XP directory and dump the argv used.
+        """
+        Initialize the XP folder. Once this is done, the XP can be retrieved
+        from its signature. This is done automatically before running,
+        or when using the `--init` flag of the `dora grid` command.
+
+        This will also initialize the shared XP folder so that the XP hyper-params
+        can be easily shared using its signature.
+        """
         xp.folder.mkdir(exist_ok=True, parents=True)
-        json.dump(xp.argv, open(xp._argv_cache, 'w'))
+        for path in [xp._argv_cache, xp._shared_argv_cache]:
+            if path is not None:
+                path.parent.mkdir(exist_ok=True, parents=True)
+                json.dump(xp.argv, open(path, 'w'))
         return xp
 
     def get_argv_from_sig(self, sig: str) -> tp.Sequence[str]:
@@ -95,6 +104,8 @@ class DecoratedMain(NamesMixin):
         xp = XP(sig=sig, dora=self.dora, cfg=None, argv=[])
         if xp._argv_cache.exists():
             return json.load(open(xp._argv_cache))
+        elif xp._shared_argv_cache is not None and xp._shared_argv_cache.exists():
+            return json.load(open(xp._shared_argv_cache))
         else:
             raise RuntimeError(f"Could not find experiment with signature {sig}")
 
@@ -194,20 +205,24 @@ class ArgparseMain(DecoratedMain):
         return super().get_slurm_config()
 
 
-def argparse_main(parser: argparse.ArgumentParser, *, use_underscore: bool = True,
-                  exclude: tp.Sequence[str] = None,
+def argparse_main(parser: argparse.ArgumentParser, *,
+                  dir: tp.Union[str, Path] = "./outputs",
+                  exclude: tp.Sequence[str] = [],
                   slurm: tp.Optional[SlurmConfig] = None,
-                  dir: tp.Union[str, Path] = "./outputs", **kwargs):
+                  shared: tp.Optional[tp.Union[str, Path]] = None,
+                  use_underscore: bool = True,
+                  **kwargs):
     """Nicer version of `ArgparseMain` that acts like a decorator, and directly
     exposes the most useful configs to override.
 
     Args:
-        parser : parser to use, and to derive default values from.
-        exclude : list of patterns of arguments to exclude from the computation
+        parser: parser to use, and to derive default values from.
+        exclude: list of patterns of arguments to exclude from the computation
             of the XP signature.
-        dir : path to store logs, checkpoints, etc. to.
-        slurm : default slurm config for scheduling jobs.
-        use_underscore : if False, scheduling a job as `launcher(batch_size=32)`
+        dir: path to store logs, checkpoints, etc. to.
+        slurm: default slurm config for scheduling jobs.
+        shared: path to the shared XP repository.
+        use_underscore: if False, scheduling a job as `launcher(batch_size=32)`
             will translate to the command-line `--batch-size=32`,
             otherwise, it will stay as `--batch_size=32`.
         **kwargs: extra args are passed to `DoraConfig`.
@@ -215,7 +230,8 @@ def argparse_main(parser: argparse.ArgumentParser, *, use_underscore: bool = Tru
     def _decorator(main: MainFun):
         dora = DoraConfig(
             dir=Path(dir),
-            exclude=list(exclude) if exclude is not None else [],
+            shared=None if shared is None else Path(shared),
+            exclude=list(exclude),
             **kwargs)
         return ArgparseMain(main, dora, parser, use_underscore=use_underscore, slurm=slurm)
     return _decorator

--- a/dora/share.py
+++ b/dora/share.py
@@ -1,0 +1,64 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+Allow to export and import XP hyper-params using base64 encoded string.
+This allows easy sharing through paste, mails etc.
+"""
+import base64
+from functools import partial
+import json
+import textwrap
+import zlib
+import sys
+
+
+from .main import DecoratedMain
+from .log import fatal, simple_log
+
+log = partial(simple_log, "Export:")
+
+
+def dump(value):
+    bits = zlib.compress(json.dumps(value).encode())
+    b64 = base64.b64encode(bits)
+    return textwrap.fill(b64.decode())
+
+
+def load(b64):
+    b64 = "".join([line.strip() for line in b64.split('\n')])
+    bits = base64.b64decode(b64)
+    jsoned = zlib.decompress(bits)
+    return json.loads(jsoned.decode())
+
+
+def export_action(args, main: DecoratedMain):
+    all_argv = []
+    for sig in args.sigs:
+        try:
+            xp = main.get_xp_from_sig(sig)
+        except RuntimeError as error:
+            fatal(f"Error loading XP {sig}: {error.args[0]}")
+        all_argv.append(xp.argv)
+    print()
+    print(dump(all_argv))
+    print()
+
+
+def import_action(args, main: DecoratedMain):
+    buffer = []
+    for line in sys.stdin.readline():
+        line = line.strip()
+        if not line and buffer:
+            break
+        if line:
+            buffer.append(line)
+    all_argv = load("".join(buffer))
+    for argv in all_argv:
+        xp = main.get_xp(argv)
+        main.init_xp(xp)
+        name = main.get_name(xp)
+        log(f"Imported XP {xp.sig}: {name}")

--- a/dora/share.py
+++ b/dora/share.py
@@ -11,9 +11,10 @@ This allows easy sharing through paste, mails etc.
 import base64
 from functools import partial
 import json
-import textwrap
-import zlib
 import sys
+import textwrap
+import typing as tp
+import zlib
 
 
 from .main import DecoratedMain
@@ -49,8 +50,8 @@ def export_action(args, main: DecoratedMain):
 
 
 def import_action(args, main: DecoratedMain):
-    buffer = []
-    for line in sys.stdin.readline():
+    buffer: tp.List[str] = []
+    for line in sys.stdin:
         line = line.strip()
         if not line and buffer:
             break

--- a/dora/tests/test_share.py
+++ b/dora/tests/test_share.py
@@ -1,0 +1,6 @@
+from dora.share import dump, load
+
+
+def test_dump_load():
+    x = [1, 2, 4, {'youpi': 'test', 'b': 56.3}]
+    assert load(dump(x)) == x

--- a/dora/xp.py
+++ b/dora/xp.py
@@ -91,6 +91,18 @@ class XP:
     def _argv_cache(self) -> Path:
         return self.folder / ".argv.json"
 
+    @property
+    def _shared_folder(self) -> tp.Optional[Path]:
+        if self.dora.shared is not None:
+            return self.dora.shared / self.dora.xps / self.sig
+        return None
+
+    @property
+    def _shared_argv_cache(self) -> tp.Optional[Path]:
+        if self._shared_folder is not None:
+            return self._shared_folder / ".argv.json"
+        return None
+
     @contextmanager
     def enter(self, stack: bool = False):
         """Context manager, fake being in the XP for its duration.


### PR DESCRIPTION
Added import/export command to easily share XP hyper-params in text form.

Added shared repository option (`shared` option in Dora config). No metrics or
checkpoints can be shared, this is still a bit dangerous, but this will act as a shared
database for mappings from SIG -> hyper params, so that you can just pass a SIG
to your teammate and launch the same XP.