### PR TITLE
Add support for explicitly setting no mem_per_gpu value 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to Demucs
+# Contributing to Dora
 
 ## Pull Requests
 
@@ -7,7 +7,7 @@ to do this once to work on any of Facebook's open source projects.
 
 Complete your CLA here: <https://code.facebook.com/cla>
 
-Wev welcome pull requests and bug fixes, however, as
+We welcome pull requests and bug fixes, however, as
 Dora is primarily intended to support research work conduted at Facebook Research,
 we do not provide strong support for running on other clusters.
 

--- a/dora/shep.py
+++ b/dora/shep.py
@@ -271,8 +271,10 @@ class Shepherd:
         else:
             gpus_per_node = gpus
             kwargs['nodes'] = 1
-        mem = slurm_config.mem_per_gpu * gpus_per_node
-        kwargs['mem'] = f"{mem}GB"
+        mem_per_gpu = slurm_config.mem_per_gpu
+        if mem_per_gpu:
+            mem = slurm_config.mem_per_gpu * gpus_per_node
+            kwargs['mem'] = f"{mem}GB"
         if slurm_config.one_task_per_node:
             kwargs['gpus_per_task'] = gpus_per_node
             kwargs['ntasks_per_node'] = 1


### PR DESCRIPTION
# Add support for explicitly specifying no `mem_per_gpu`

This PR allows users to specify `mem_per_gpu=None` for Slurm. This has been tested specifying it through the yaml config, in the grid launcher.