### PR TITLE
Update SLURM config to use gres

### DIFF
--- a/dora/__init__.py
+++ b/dora/__init__.py
@@ -60,7 +60,7 @@ width="400px"></p>
 __pdoc__ = {}
 __pdoc__['tests'] = False
 
-__version__ = "0.1.12a1"
+__version__ = "0.1.12a2"
 
 # flake8: noqa
 from .explore import Explorer, Launcher
@@ -76,4 +76,3 @@ from .link import Link
 from .main import argparse_main
 from .shep import Sheep
 from .xp import get_xp, is_xp, XP
-

--- a/dora/shep.py
+++ b/dora/shep.py
@@ -277,13 +277,12 @@ class Shepherd:
         if mem_per_gpu:
             mem = slurm_config.mem_per_gpu * gpus_per_node
             kwargs['mem'] = f"{mem}GB"
+        kwargs['gres'] = f'gpu:{gpus}'
         if slurm_config.one_task_per_node:
-            kwargs['gpus_per_task'] = gpus_per_node
             kwargs['ntasks_per_node'] = 1
             if slurm_config.cpus_per_task is None:
                 kwargs['cpus_per_task'] = gpus_per_node * slurm_config.cpus_per_gpu
         else:
-            kwargs['gpus_per_task'] = 1
             kwargs['ntasks_per_node'] = gpus_per_node
             if slurm_config.cpus_per_task is None:
                 kwargs['cpus_per_task'] = slurm_config.cpus_per_gpu


### PR DESCRIPTION
This PR update the SLURM config used by dora to use gres for specifying the number of GPUs used in the job.